### PR TITLE
Corrected errors in the generated <meta> elements.

### DIFF
--- a/htmlbook-autogen/document.html.erb
+++ b/htmlbook-autogen/document.html.erb
@@ -7,7 +7,8 @@ xmlns="http://www.w3.org/1999/xhtml">
 <% toc_levels = (attr? :levels) ? (attr :levels).to_i : (@document.attr :toclevels, 2).to_i %>
   <head>
     <title><%= doctitle %></title>
-    <meta name="<%= doctitle %>" content="text/html; charset=utf-8"/>
+    <meta charset="utf-8"/>
+    <meta name="title" content="<%= doctitle %>"/>
 
     <% if attr? :author %>
       <meta name="author" content="<%= attr :author %>"/>


### PR DESCRIPTION
The document title was erroneously being used as the value of the name
attribute of the meta element declaring the document encoding. Now
separate meta elements are generated for the encoding and title.
