### PR TITLE
Handle covers

### DIFF
--- a/gitberg-machine/requirements.txt
+++ b/gitberg-machine/requirements.txt
@@ -4,6 +4,7 @@ PyYAML==3.11
 SPARQLWrapper==1.6.4
 git+git://github.com/gitenberg-dev/metadata.git@0.1.11
 #gitenberg.metadata==0.1.10
+git+https://github.com/Gluejar/pyepub
 html5lib==0.999999
 isodate==0.5.1
 pymarc==3.0.3

--- a/htmlbook-autogen/document.html.erb
+++ b/htmlbook-autogen/document.html.erb
@@ -16,9 +16,11 @@ xmlns="http://www.w3.org/1999/xhtml">
   </head>
 <body<%= @id && %( id="#{@id}") %> data-type="book">
   <% if @header %><h1><%= @header.title %></h1><% end %>
+  <% if attr? :cover %>
   <figure data-type="cover">
-    <img src="cover.jpg"/>
+    <img src="<%= attr :cover %>"/>
   </figure>
+  <% end %>
   <section data-type="titlepage">
     <% if @header %><h1><%= @header.title %></h1><% end %>
     <% if attr? :author %><p data-type="author"><%= attr :author %></p><% end %>

--- a/htmlbook-autogen/document.html.erb
+++ b/htmlbook-autogen/document.html.erb
@@ -16,11 +16,21 @@ xmlns="http://www.w3.org/1999/xhtml">
   </head>
 <body<%= @id && %( id="#{@id}") %> data-type="book">
   <% if @header %><h1><%= @header.title %></h1><% end %>
+  {% if cover %}
+  <figure data-type="cover">
+    <img src="{{ cover }}"/>
+  </figure>
+  {% else %}
   <% if attr? :cover %>
   <figure data-type="cover">
     <img src="<%= attr :cover %>"/>
   </figure>
+  <% else %>
+  <figure data-type="cover">
+    <img src="cover.jpg"/>
+  </figure>
   <% end %>
+  {% endif %}
   <section data-type="titlepage">
     <% if @header %><h1><%= @header.title %></h1><% end %>
     <% if attr? :author %><p data-type="author"><%= attr :author %></p><% end %>


### PR DESCRIPTION
only cover supported was one at cover.jpg. now supports covers added via document attributes (erb code) or from the yaml metadata (jinja2 code)